### PR TITLE
[npm-users] Add @pigment-css as an npm org option

### DIFF
--- a/toolpad/pages/npmUsers/page.yml
+++ b/toolpad/pages/npmUsers/page.yml
@@ -36,6 +36,8 @@ spec:
                 label: "@mui"
               - value: toolpad
                 label: "@toolpad"
+              - value: pigment-css
+                label: "@pigment-css"                
             defaultValue: mui
             name: ""
     - component: DataGrid


### PR DESCRIPTION
Add pigment-css as an npm org. I wasn't able to test this locally as I don't have the tokens, but it should work 😄 